### PR TITLE
Fix MSVC link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ set(USE_TZCNT ON)
 set(USE_F16C ON)
 set(USE_FMADD ON)
 
+set(WINDOWS_STORE ON)
 # Include Jolt
 FetchContent_Declare(
         JoltPhysics


### PR DESCRIPTION
Raylib and Jolt use differen Runtime Libraries.
Raylib uses dynamic Runtime Library transitively from [glfw](https://github.com/raysan5/raylib/blob/efc0fed9ce23406658fa0c8e4a4e934073a1d62f/src/external/glfw/CMakeLists.txt#L46)
and Jolt uses [static runtime library unless it's windows store application](https://github.com/jrouwe/JoltPhysics/blob/d4c4cffb53d31db7bbe62f8fd8749c61ee1ba36e/Build/CMakeLists.txt#L60).
As a quick hack, I force WINDOWS_STORE flag before configuring Jolt.